### PR TITLE
Handle range ghosts in cql backend

### DIFF
--- a/lib/shearwater/cassandra_cql_backend.rb
+++ b/lib/shearwater/cassandra_cql_backend.rb
@@ -28,7 +28,7 @@ module Shearwater
       execute(
         "SELECT version, migrated_at FROM #{@column_family}"
       ).fetch { |row| rows << row.to_hash }
-      row = rows.reject { |row| row['migrated_at'] == nil }.sort { |row1, row2| row1['version'].to_i <=> row2['version'].to_i }.last
+      row = rows.reject { |row| row['migrated_at'].nil? }.sort { |row1, row2| row1['version'].to_i <=> row2['version'].to_i }.last
       row['version'].to_i if row
     end
 

--- a/lib/shearwater/cassandra_cql_backend.rb
+++ b/lib/shearwater/cassandra_cql_backend.rb
@@ -28,7 +28,7 @@ module Shearwater
       execute(
         "SELECT version, migrated_at FROM #{@column_family}"
       ).fetch { |row| rows << row.to_hash }
-      row = rows.sort { |row1, row2| row1['version'].to_i <=> row2['version'].to_i }.last
+      row = rows.reject { |row| row['migrated_at'] == nil }.sort { |row1, row2| row1['version'].to_i <=> row2['version'].to_i }.last
       row['version'].to_i if row
     end
 

--- a/spec/examples/cassandra_cql_backend_spec.rb
+++ b/spec/examples/cassandra_cql_backend_spec.rb
@@ -1,0 +1,29 @@
+require File.expand_path('../spec_helper', __FILE__)
+require 'shearwater/cassandra_cql_backend'
+
+class CassandraStubResults
+  def initialize(row_hashes)
+    @row_hashes = row_hashes
+  end
+
+  def fetch
+    @row_hashes.each do |row_hash|
+      yield row_hash
+    end
+  end
+end
+
+describe Shearwater::CassandraCqlBackend do
+  describe "#last_migration" do
+    it "ignores 'range ghosts' when identifying the last migration" do
+      connection = stub('connection')
+      stubbed_cassandra_results = CassandraStubResults.new([
+        { 'version' => 1, 'migrated_at' => 2342342 },
+        { 'version' => 2, 'migrated_at' => nil }
+      ])
+      connection.stub_chain(:execute).and_return(stubbed_cassandra_results)
+      backend = Shearwater::CassandraCqlBackend.new(connection)
+      backend.last_migration.should == 1
+    end
+  end
+end


### PR DESCRIPTION
I did this because when you have your Cassandra schema_migrations column
family setup as follows you end up still getting "range ghosts". This was
breaking the last_migration method in such a way that I was always getting a
migration that I had previously rollback and was now a "range ghost" as the
last_migration result.

`CREATE COLUMNFAMILY schema_migrations (version int PRIMARY KEY, migrated_at timestamp)`

As a side effect of this it was causing Migrator rollback method to all keep trying to rollback the migration it just rolled back.
